### PR TITLE
fix(auth): enforce stable cookies config for reverse proxy compatibility

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -118,6 +118,18 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
       // No adapter - using pure JWT sessions (industry standard for OIDC)
       session: { strategy: 'jwt', maxAge: sessionMaxAgeSeconds },
       jwt: { maxAge: sessionMaxAgeSeconds },
+      // Enforce stable cookie name and attributes for reverse proxy compatibility (Cloudflare Tunnel)
+      cookies: {
+        sessionToken: {
+          name: 'next-auth.session-token',
+          options: {
+            httpOnly: true,
+            sameSite: 'lax',
+            path: '/',
+            secure: true,
+          },
+        },
+      },
       // Trust host headers if explicit env var is set OR if NEXTAUTH_URL is configured (which locks the origin)
       trustHost: !!(process.env.AUTH_TRUST_HOST || process.env.NEXTAUTH_URL),
       providers: [


### PR DESCRIPTION
## Overview
This PR adds a custom `cookies` block to NextAuth's options in `src/lib/auth.ts` to enforce stable cookie names (`next-auth.session-token`) and configurations (`secure: true`) regardless of the detected request protocol (HTTP vs HTTPS).

### The Problem
When running behind Cloudflare Tunnel (or any reverse proxy), the external connection is HTTPS, but the internal forwarding to the Next.js container on port 3000 is HTTP.
Consequently, NextAuth's server-side layout logic (`getServerSession`) detects HTTP and expects an unsecure cookie (`next-auth.session-token`), whereas standard login set a secure cookie (`__Secure-next-auth.session-token`) due to `NEXTAUTH_URL` starting with `https://`. This mismatch caused the server to think there was no session on layout rendering, redirecting users immediately back to `/login?error=SessionExpired`.

### The Solution
Forcing the stable cookie configuration matches both writing and reading states cleanly under Cloudflare reverse proxy environments, fixing the infinite login loop.