### PR TITLE
fix(auth): align middleware token check with custom stable cookie name

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-﻿import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { logger } from '@/lib/logger';
 import { getNextAuthSecret } from '@/lib/secret-manager';
@@ -325,7 +325,11 @@ export default async function middleware(req: NextRequest) {
   }
 
   // Check authentication status
-  const token = await getToken({ req, secret: await getNextAuthSecret() });
+  const token = await getToken({
+    req,
+    secret: await getNextAuthSecret(),
+    cookieName: 'next-auth.session-token',
+  });
   // Check if token exists AND is valid (not revoked/errored)
   const isAuthenticated = !!token && !token.error && !!token.sub;
 


### PR DESCRIPTION
## Overview
This PR aligns the token retrieval call inside `src/middleware.ts` with the custom stable cookie configuration we enforced in `getAuthOptions()` (`next-auth.session-token`).

### The Problem
While `getServerSession` inside Layout rendering utilized the custom cookie configuration, the Edge Middleware's `getToken` function was left without the custom cookie name configuration. Thus, in production (detecting HTTPS), `getToken` defaulted to searching for `__Secure-next-auth.session-token`. Since we enforced the cookie name as `next-auth.session-token` to resolve the reverse proxy mismatch, the middleware failed to locate the session cookie and redirected authenticated users back to login indefinitely.

### The Solution
Enforcing `cookieName: 'next-auth.session-token'` in the `getToken` options resolves this mismatch completely.