### PR TITLE
fix(auth): industry-standard cookie naming with environment-aware Secure flag

### DIFF
--- a/src/lib/auth-cookies.ts
+++ b/src/lib/auth-cookies.ts
@@ -1,0 +1,25 @@
+/**
+ * Centralized NextAuth cookie configuration.
+ *
+ * NextAuth's built-in auto-detection of `useSecureCookies` reads the request
+ * protocol, which is unreliable behind reverse proxies (Cloudflare Tunnel
+ * terminates TLS and forwards HTTP). We derive the protocol from NEXTAUTH_URL
+ * — an explicit, environment-controlled value — so prod (HTTPS) and test/dev
+ * (HTTP) each get the correct cookie shape:
+ *
+ *   - HTTPS: `__Secure-` / `__Host-` prefixed names, Secure flag set
+ *   - HTTP:  unprefixed names, Secure flag cleared (browsers reject Secure
+ *            cookies over HTTP, which would otherwise cause a login loop)
+ *
+ * Both `getAuthOptions()` and the edge middleware must agree on the cookie
+ * name, so they both import from this module.
+ */
+
+export const useSecureCookies = (process.env.NEXTAUTH_URL ?? '').startsWith('https://');
+
+const cookiePrefix = useSecureCookies ? '__Secure-' : '';
+const hostCookiePrefix = useSecureCookies ? '__Host-' : '';
+
+export const SESSION_TOKEN_COOKIE_NAME = `${cookiePrefix}next-auth.session-token`;
+export const CALLBACK_URL_COOKIE_NAME = `${cookiePrefix}next-auth.callback-url`;
+export const CSRF_TOKEN_COOKIE_NAME = `${hostCookiePrefix}next-auth.csrf-token`;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,12 @@ import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { getOidcConfig } from '@/lib/oidc-config';
 import { getDefaultAvatar } from '@/lib/avatar';
+import {
+  SESSION_TOKEN_COOKIE_NAME,
+  CALLBACK_URL_COOKIE_NAME,
+  CSRF_TOKEN_COOKIE_NAME,
+  useSecureCookies,
+} from '@/lib/auth-cookies';
 
 function getJwtUserRefreshTtlMs() {
   const raw = process.env.JWT_USER_REFRESH_TTL_MS ?? '60000';
@@ -118,16 +124,36 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
       // No adapter - using pure JWT sessions (industry standard for OIDC)
       session: { strategy: 'jwt', maxAge: sessionMaxAgeSeconds },
       jwt: { maxAge: sessionMaxAgeSeconds },
-      // Enforce stable cookie name and attributes for reverse proxy compatibility (Cloudflare Tunnel).
-      // `secure` is derived from NEXTAUTH_URL so non-HTTPS test/dev envs can still set the cookie.
+      // Explicit cookie config (see src/lib/auth-cookies.ts).
+      // We derive `secure` and the `__Secure-` / `__Host-` prefixes from
+      // NEXTAUTH_URL rather than relying on NextAuth's request-based protocol
+      // detection, which is unreliable behind Cloudflare Tunnel.
+      useSecureCookies,
       cookies: {
         sessionToken: {
-          name: 'next-auth.session-token',
+          name: SESSION_TOKEN_COOKIE_NAME,
           options: {
             httpOnly: true,
             sameSite: 'lax',
             path: '/',
-            secure: (process.env.NEXTAUTH_URL ?? '').startsWith('https://'),
+            secure: useSecureCookies,
+          },
+        },
+        callbackUrl: {
+          name: CALLBACK_URL_COOKIE_NAME,
+          options: {
+            sameSite: 'lax',
+            path: '/',
+            secure: useSecureCookies,
+          },
+        },
+        csrfToken: {
+          name: CSRF_TOKEN_COOKIE_NAME,
+          options: {
+            httpOnly: true,
+            sameSite: 'lax',
+            path: '/',
+            secure: useSecureCookies,
           },
         },
       },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -118,7 +118,8 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
       // No adapter - using pure JWT sessions (industry standard for OIDC)
       session: { strategy: 'jwt', maxAge: sessionMaxAgeSeconds },
       jwt: { maxAge: sessionMaxAgeSeconds },
-      // Enforce stable cookie name and attributes for reverse proxy compatibility (Cloudflare Tunnel)
+      // Enforce stable cookie name and attributes for reverse proxy compatibility (Cloudflare Tunnel).
+      // `secure` is derived from NEXTAUTH_URL so non-HTTPS test/dev envs can still set the cookie.
       cookies: {
         sessionToken: {
           name: 'next-auth.session-token',
@@ -126,7 +127,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             httpOnly: true,
             sameSite: 'lax',
             path: '/',
-            secure: true,
+            secure: (process.env.NEXTAUTH_URL ?? '').startsWith('https://'),
           },
         },
       },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { logger } from '@/lib/logger';
 import { getNextAuthSecret } from '@/lib/secret-manager';
+import { SESSION_TOKEN_COOKIE_NAME, useSecureCookies } from '@/lib/auth-cookies';
 
 const PUBLIC_PATH_PREFIXES = [
   '/login',
@@ -328,7 +329,8 @@ export default async function middleware(req: NextRequest) {
   const token = await getToken({
     req,
     secret: await getNextAuthSecret(),
-    cookieName: 'next-auth.session-token',
+    cookieName: SESSION_TOKEN_COOKIE_NAME,
+    secureCookie: useSecureCookies,
   });
   // Check if token exists AND is valid (not revoked/errored)
   const isAuthenticated = !!token && !token.error && !!token.sub;


### PR DESCRIPTION
## Summary
- Existing prod fix (#191, #192) hardcoded `next-auth.session-token` with `secure: true`, which works behind Cloudflare HTTPS but breaks any non-HTTPS environment (test/dev served over plain HTTP). Browsers refuse to store `Secure` cookies over HTTP → infinite login → redirect loop, identical symptom to the original prod bug.
- Replaces the override with NextAuth's standard prefix convention: `__Secure-` / `__Host-` on HTTPS, unprefixed on HTTP, `Secure` flag tied to URL protocol.
- Protocol is derived from `NEXTAUTH_URL` (explicit env value) rather than NextAuth's request-based auto-detection, which is the unreliable mechanism behind the original Cloudflare Tunnel bug.

## Changes
- New `src/lib/auth-cookies.ts` — single source of truth for session/callback/csrf cookie names and the `useSecureCookies` flag.
- `src/lib/auth.ts` — configures all three NextAuth cookies (sessionToken, callbackUrl, csrfToken) consistently, sets `useSecureCookies` explicitly.
- `src/middleware.ts` — `getToken` now imports the same cookie name and passes `secureCookie` explicitly, so edge runtime stays in sync.

## Expected behavior per env
| Env | NEXTAUTH_URL | Session cookie name | Secure flag |
|---|---|---|---|
| Prod (Cloudflare) | https://... | `__Secure-next-auth.session-token` | true |
| Test (HTTP) | http://... | `next-auth.session-token` | false |
| Dev (localhost) | http://localhost:3000 | `next-auth.session-token` | false |

## Test plan
- [ ] Verify login works on test env (HTTP) without redirect loop
- [ ] Verify login still works on prod (HTTPS via Cloudflare Tunnel)
- [ ] Confirm existing prod sessions are invalidated on deploy (cookie name changes from `next-auth.session-token` → `__Secure-next-auth.session-token`; users will need to log in once)
- [ ] Verify middleware redirects unauthenticated users to /login as expected
- [ ] Verify password reset flow still clears stale cookies (page already clears both prefixed + unprefixed variants)

## Note on cookie rotation
Prod cookie name changes from `next-auth.session-token` to `__Secure-next-auth.session-token` on this deploy. Existing logged-in users will be silently logged out and need to log in once. This is acceptable — `__Secure-` is the conventional name and matches what NextAuth produces by default for HTTPS deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)