### PR TITLE
feat(jira): service-owned project routing + urgency auto-create

### DIFF
--- a/prisma/migrations/20260523143000_add_jira_auto_create_urgency_filter/migration.sql
+++ b/prisma/migrations/20260523143000_add_jira_auto_create_urgency_filter/migration.sql
@@ -1,0 +1,5 @@
+-- Additive, rolling-safe service-level filter for Jira incident auto-creation.
+-- Empty array preserves the prior behavior: when auto-create is enabled, all
+-- incident urgencies are eligible until a service explicitly narrows it.
+ALTER TABLE "JiraServiceMapping"
+  ADD COLUMN "autoCreateIncidentUrgencies" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -688,17 +688,18 @@ model JiraConfig {
 }
 
 model JiraServiceMapping {
-  id                      String   @id @default(cuid())
-  serviceId               String   @unique
-  projectKey              String
-  incidentIssueType       String
-  actionItemIssueType     String
-  defaultLabels           String[] @default([])
-  defaultComponent        String?
-  autoCreateIncidentIssue Boolean  @default(false)
-  syncEnabled             Boolean  @default(true)
-  createdAt               DateTime @default(now())
-  updatedAt               DateTime @updatedAt
+  id                          String   @id @default(cuid())
+  serviceId                   String   @unique
+  projectKey                  String
+  incidentIssueType           String
+  actionItemIssueType         String
+  defaultLabels               String[] @default([])
+  defaultComponent            String?
+  autoCreateIncidentIssue     Boolean  @default(false)
+  autoCreateIncidentUrgencies String[] @default([])
+  syncEnabled                 Boolean  @default(true)
+  createdAt                   DateTime @default(now())
+  updatedAt                   DateTime @updatedAt
 
   service Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
 

--- a/src/app/(app)/action-items/jira/actions.ts
+++ b/src/app/(app)/action-items/jira/actions.ts
@@ -33,13 +33,15 @@ export async function createJiraIssueFromActionItem(actionItemId: string) {
 
   const jiraConfig = await prisma.jiraConfig.findUnique({
     where: { id: 'default' },
-    select: { defaultProjectKey: true, enabled: true },
+    select: { enabled: true },
   });
 
   if (!jiraConfig?.enabled) throw new Error('Jira is not configured or is disabled.');
 
-  const projectKey = mapping?.projectKey ?? jiraConfig.defaultProjectKey;
-  if (!projectKey) throw new Error('No Jira project key configured.');
+  const projectKey = mapping?.projectKey;
+  if (!projectKey) {
+    throw new Error('Configure a Jira project for this action item service first.');
+  }
 
   const issueType = mapping?.actionItemIssueType ?? 'Task';
   const labels = mapping?.defaultLabels ?? ['opsknight'];

--- a/src/app/(app)/incidents/[id]/page.tsx
+++ b/src/app/(app)/incidents/[id]/page.tsx
@@ -60,6 +60,9 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
       service: {
         include: {
           policy: true,
+          jiraServiceMapping: {
+            select: { projectKey: true },
+          },
         },
       },
       assignee: true,
@@ -598,8 +601,10 @@ export default async function IncidentDetailPage({ params }: { params: Promise<{
           {/* Jira Issues */}
           <IncidentJiraCard
             incidentId={id}
+            serviceSettingsHref={`/services/${incident.serviceId}/settings`}
             jiraLinks={jiraLinks}
             jiraEnabled={jiraConfig?.enabled ?? false}
+            serviceJiraMapped={Boolean(incident.service.jiraServiceMapping?.projectKey)}
             canManage={canManageIncident}
           />
 

--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -2,7 +2,6 @@
 
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
-import { redirect } from 'next/navigation';
 import { IncidentStatus, IncidentUrgency } from '@prisma/client';
 import { getCurrentUser, assertResponderOrAbove, assertCanModifyIncident } from '@/lib/rbac';
 import { getUserFriendlyError } from '@/lib/user-friendly-errors';
@@ -583,7 +582,11 @@ export async function createIncident(formData: FormData) {
   });
 
   // If we reopened a recently resolved incident, immediately schedule the first escalation step
-  if (incident.status === 'OPEN' && incident.resolvedAt === null && incident.currentEscalationStep === 0) {
+  if (
+    incident.status === 'OPEN' &&
+    incident.resolvedAt === null &&
+    incident.currentEscalationStep === 0
+  ) {
     try {
       const { scheduleEscalation } = await import('@/lib/jobs/queue');
       // Retry up to 3 times with short backoff to ensure the first escalation job is queued
@@ -679,6 +682,60 @@ export async function createIncident(formData: FormData) {
     await notifyStatusPageSubscribers(incident.id, 'triggered');
   } catch (e) {
     logger.error('Status page subscriber notification failed', {
+      component: 'incidents-actions',
+      error: e,
+      incidentId: incident.id,
+    });
+  }
+
+  // Optional Jira automation. This is intentionally best-effort so Jira
+  // outages never block incident creation during rolling deployments.
+  try {
+    const incidentForJira = await prisma.incident.findUnique({
+      where: { id: incident.id },
+      include: {
+        service: { include: { jiraServiceMapping: true } },
+        externalIssueLinks: { where: { provider: 'JIRA' }, select: { id: true } },
+      },
+    });
+
+    const mapping = incidentForJira?.service?.jiraServiceMapping;
+    if (
+      incidentForJira &&
+      mapping?.autoCreateIncidentIssue &&
+      (mapping.autoCreateIncidentUrgencies.length === 0 ||
+        mapping.autoCreateIncidentUrgencies.includes(incidentForJira.urgency)) &&
+      incidentForJira.externalIssueLinks.length === 0
+    ) {
+      const jiraConfig = await prisma.jiraConfig.findUnique({
+        where: { id: 'default' },
+        select: { enabled: true },
+      });
+
+      if (jiraConfig?.enabled) {
+        const { createJiraIssueAndLink } = await import('@/lib/jira-sync');
+        const { issue } = await createJiraIssueAndLink({
+          incidentId: incident.id,
+          projectKey: mapping.projectKey,
+          issueType: mapping.incidentIssueType || 'Bug',
+          summary: `[Incident] ${incidentForJira.title}`,
+          description:
+            incidentForJira.description || `OpsKnight Incident: ${incidentForJira.title}`,
+          labels: mapping.defaultLabels.length > 0 ? mapping.defaultLabels : ['opsknight'],
+          component: mapping.defaultComponent,
+        });
+
+        await prisma.incidentEvent.create({
+          data: {
+            incidentId: incident.id,
+            type: 'COMMENT',
+            message: `Jira issue ${issue.key} auto-created`,
+          },
+        });
+      }
+    }
+  } catch (e) {
+    logger.error('Jira issue auto-create failed', {
       component: 'incidents-actions',
       error: e,
       incidentId: incident.id,

--- a/src/app/(app)/incidents/jira/actions.ts
+++ b/src/app/(app)/incidents/jira/actions.ts
@@ -29,13 +29,15 @@ export async function createJiraIssueFromIncident(incidentId: string) {
 
   const jiraConfig = await prisma.jiraConfig.findUnique({
     where: { id: 'default' },
-    select: { defaultProjectKey: true, enabled: true },
+    select: { enabled: true },
   });
 
   if (!jiraConfig?.enabled) throw new Error('Jira is not configured or is disabled.');
 
-  const projectKey = mapping?.projectKey ?? jiraConfig.defaultProjectKey;
-  if (!projectKey) throw new Error('No Jira project key configured for this service or workspace.');
+  const projectKey = mapping?.projectKey;
+  if (!projectKey) {
+    throw new Error('Configure a Jira project for this service before creating Jira issues.');
+  }
 
   const issueType = mapping?.incidentIssueType ?? 'Bug';
   const labels = mapping?.defaultLabels ?? ['opsknight'];

--- a/src/app/(app)/postmortems/actions.ts
+++ b/src/app/(app)/postmortems/actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { getCurrentUser, assertResponderOrAbove } from '@/lib/rbac';
 import {
   getStoredActionItemId,
+  normalizeLegacyActionItems,
   parseActionItemDueDate,
   resolveStoredActionItems,
   type ActionItem,
@@ -208,7 +209,71 @@ export async function getPostmortem(incidentId: string) {
     return null;
   }
 
-  const { actionItemRecords, actionItems, ...rest } = postmortem;
+  let { actionItemRecords } = postmortem;
+  const { actionItems, ...rest } = postmortem;
+
+  // Rolling migration aid: old postmortems may still only have JSON action
+  // items. Hydrate normalized rows on first read so Jira linking works without
+  // requiring a maintenance window.
+  if (actionItemRecords.length === 0) {
+    const legacyItems = normalizeLegacyActionItems(actionItems, {
+      legacyIdPrefix: `postmortem-${postmortem.id}`,
+    });
+
+    if (legacyItems.length > 0) {
+      await prisma.$transaction(async tx => {
+        for (const [index, item] of legacyItems.entries()) {
+          await tx.actionItem.upsert({
+            where: {
+              id: getStoredActionItemId({
+                postmortemId: postmortem.id,
+                legacyId: item.id,
+                index,
+              }),
+            },
+            update: {},
+            create: {
+              id: getStoredActionItemId({
+                postmortemId: postmortem.id,
+                legacyId: item.id,
+                index,
+              }),
+              postmortemId: postmortem.id,
+              incidentId: postmortem.incident.id,
+              title: item.title.trim() || 'Untitled action item',
+              description: item.description.trim() || null,
+              ownerId: item.owner || null,
+              dueDate: parseActionItemDueDate(item.dueDate) ?? null,
+              status: item.status,
+              priority: item.priority,
+              source: 'POSTMORTEM',
+              completedAt: item.status === 'COMPLETED' ? new Date() : null,
+            },
+          });
+        }
+      });
+
+      actionItemRecords = await prisma.actionItem.findMany({
+        where: { postmortemId: postmortem.id },
+        include: {
+          externalIssueLinks: {
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+            select: {
+              id: true,
+              provider: true,
+              externalKey: true,
+              externalUrl: true,
+              externalStatus: true,
+              externalAssignee: true,
+              syncState: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+      });
+    }
+  }
 
   return {
     ...rest,

--- a/src/app/(app)/services/[id]/settings/page.tsx
+++ b/src/app/(app)/services/[id]/settings/page.tsx
@@ -2,7 +2,9 @@ import prisma from '@/lib/prisma';
 import Link from 'next/link';
 import ServiceTabs from '@/components/service/ServiceTabs';
 import ServiceNotificationSettings from '@/components/service/ServiceNotificationSettings';
+import JiraServiceMappingSettings from '@/components/service/JiraServiceMappingSettings';
 import { updateService } from '../../actions';
+import { getUserPermissions } from '@/lib/rbac';
 import {
   Card,
   CardContent,
@@ -37,38 +39,45 @@ export default async function ServiceSettingsPage({
   const showSaved = resolvedSearchParams?.saved === '1';
   const errorCode = resolvedSearchParams?.error;
 
-  const [service, teams, policies, globalSlackIntegration] = await Promise.all([
-    prisma.service.findUnique({
-      where: { id: id },
-      include: {
-        policy: {
-          select: { id: true, name: true },
+  const [service, teams, policies, globalSlackIntegration, jiraConfig, permissions] =
+    await Promise.all([
+      prisma.service.findUnique({
+        where: { id: id },
+        include: {
+          policy: {
+            select: { id: true, name: true },
+          },
+          webhookIntegrations: {
+            where: { enabled: true },
+            orderBy: { createdAt: 'desc' },
+          },
+          jiraServiceMapping: true,
         },
-        webhookIntegrations: {
-          where: { enabled: true },
-          orderBy: { createdAt: 'desc' },
+      }),
+      prisma.team.findMany({ orderBy: { name: 'asc' } }),
+      prisma.escalationPolicy.findMany({
+        select: { id: true, name: true },
+        orderBy: { name: 'asc' },
+      }),
+      prisma.slackIntegration.findFirst({
+        where: {
+          enabled: true,
+          service: null,
         },
-      },
-    }),
-    prisma.team.findMany({ orderBy: { name: 'asc' } }),
-    prisma.escalationPolicy.findMany({
-      select: { id: true, name: true },
-      orderBy: { name: 'asc' },
-    }),
-    prisma.slackIntegration.findFirst({
-      where: {
-        enabled: true,
-        service: null,
-      },
-      select: {
-        id: true,
-        workspaceName: true,
-        workspaceId: true,
-        enabled: true,
-      },
-      orderBy: { updatedAt: 'desc' },
-    }),
-  ]);
+        select: {
+          id: true,
+          workspaceName: true,
+          workspaceId: true,
+          enabled: true,
+        },
+        orderBy: { updatedAt: 'desc' },
+      }),
+      prisma.jiraConfig.findUnique({
+        where: { id: 'default' },
+        select: { enabled: true },
+      }),
+      getUserPermissions(),
+    ]);
 
   // Get webhook integrations separately (already included in service)
   const webhookIntegrations = service?.webhookIntegrations || [];
@@ -79,7 +88,9 @@ export default async function ServiceSettingsPage({
         <Card className="text-center py-12">
           <div className="flex flex-col items-center justify-center p-6">
             <h2 className="text-2xl font-semibold mb-2">Service Not Found</h2>
-            <p className="text-slate-500 mb-6">The service you're looking for doesn't exist.</p>
+            <p className="text-slate-500 mb-6">
+              The service you&apos;re looking for doesn&apos;t exist.
+            </p>
             <Button asChild>
               <Link href="/services">Back to Services</Link>
             </Button>
@@ -90,6 +101,7 @@ export default async function ServiceSettingsPage({
   }
 
   const updateServiceWithId = updateService.bind(null, id);
+  const canManage = permissions.isResponderOrAbove;
 
   return (
     <main className="w-full px-3 sm:px-4 md:px-6 lg:px-8 py-4 sm:py-6 space-y-4 sm:space-y-6">
@@ -322,6 +334,13 @@ export default async function ServiceSettingsPage({
             </Button>
           </div>
         </form>
+
+        <JiraServiceMappingSettings
+          serviceId={service.id}
+          mapping={service.jiraServiceMapping}
+          jiraEnabled={jiraConfig?.enabled ?? false}
+          canManage={canManage}
+        />
       </div>
     </main>
   );

--- a/src/app/(app)/services/actions.ts
+++ b/src/app/(app)/services/actions.ts
@@ -9,6 +9,8 @@ import { assertAdminOrResponder, assertAdmin } from '@/lib/rbac';
 import { assertServiceNameAvailable, UniqueNameConflictError } from '@/lib/unique-names';
 import { assertJiraIssueType, assertJiraProjectKey, parseLabels } from '@/lib/jira-validation';
 
+const JIRA_AUTO_CREATE_URGENCIES = new Set(['HIGH', 'MEDIUM', 'LOW']);
+
 export async function createIntegration(formData: FormData) {
   try {
     await assertAdminOrResponder();
@@ -179,7 +181,18 @@ export async function saveJiraServiceMapping(
     const defaultComponent =
       ((formData.get('defaultComponent') as string | null) ?? '').trim() || null;
     const autoCreateIncidentIssue = formData.get('autoCreateIncidentIssue') === 'on';
+    const autoCreateIncidentUrgencies = formData
+      .getAll('autoCreateIncidentUrgencies')
+      .map(value => String(value).trim().toUpperCase())
+      .filter(value => JIRA_AUTO_CREATE_URGENCIES.has(value));
     const syncEnabled = formData.get('syncEnabled') === 'on';
+
+    if (autoCreateIncidentIssue && autoCreateIncidentUrgencies.length === 0) {
+      return {
+        error:
+          'Select at least one incident urgency for Jira auto-create, or turn auto-create off.',
+      };
+    }
 
     const service = await prisma.service.findUnique({
       where: { id: serviceId },
@@ -197,6 +210,7 @@ export async function saveJiraServiceMapping(
         defaultLabels,
         defaultComponent,
         autoCreateIncidentIssue,
+        autoCreateIncidentUrgencies,
         syncEnabled,
       },
       update: {
@@ -206,6 +220,7 @@ export async function saveJiraServiceMapping(
         defaultLabels,
         defaultComponent,
         autoCreateIncidentIssue,
+        autoCreateIncidentUrgencies,
         syncEnabled,
       },
     });
@@ -222,6 +237,7 @@ export async function saveJiraServiceMapping(
         defaultLabels,
         defaultComponent,
         autoCreateIncidentIssue,
+        autoCreateIncidentUrgencies,
         syncEnabled,
       },
     });

--- a/src/app/(app)/settings/integrations/jira/actions.ts
+++ b/src/app/(app)/settings/integrations/jira/actions.ts
@@ -4,7 +4,7 @@ import prisma from '@/lib/prisma';
 import { encrypt } from '@/lib/encryption';
 import { logAudit } from '@/lib/audit';
 import { assertAdmin, getCurrentUser } from '@/lib/rbac';
-import { normalizeJiraBaseUrl, assertJiraProjectKey } from '@/lib/jira-validation';
+import { normalizeJiraBaseUrl } from '@/lib/jira-validation';
 import { revalidatePath } from 'next/cache';
 
 type JiraConfigState = {
@@ -28,7 +28,6 @@ export async function saveJiraConfig(
     const baseUrl = normalizeJiraBaseUrl((formData.get('baseUrl') as string | null) ?? '');
     const userEmail = ((formData.get('userEmail') as string | null) ?? '').trim().toLowerCase();
     const apiToken = ((formData.get('apiToken') as string | null) ?? '').trim();
-    const defaultProjectInput = ((formData.get('defaultProjectKey') as string | null) ?? '').trim();
     const webhookSecret = ((formData.get('webhookSecret') as string | null) ?? '').trim();
     const enabledValue = formData.get('enabled');
     const enabled = enabledValue === 'on' || enabledValue === 'true';
@@ -36,10 +35,6 @@ export async function saveJiraConfig(
     if (!userEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(userEmail)) {
       return { error: 'A valid Jira user email is required.' };
     }
-
-    const defaultProjectKey = defaultProjectInput
-      ? assertJiraProjectKey(defaultProjectInput)
-      : null;
 
     const existing = await prisma.jiraConfig.findUnique({ where: { id: 'default' } });
     if (!existing && !apiToken) {
@@ -67,7 +62,7 @@ export async function saveJiraConfig(
         userEmail,
         apiTokenEncrypted,
         enabled,
-        defaultProjectKey,
+        defaultProjectKey: null,
         webhookSecretEncrypted,
         updatedBy: user.id,
       },
@@ -76,7 +71,7 @@ export async function saveJiraConfig(
         userEmail,
         apiTokenEncrypted,
         enabled,
-        defaultProjectKey,
+        defaultProjectKey: null,
         webhookSecretEncrypted,
         updatedBy: user.id,
       },
@@ -91,7 +86,6 @@ export async function saveJiraConfig(
         enabled,
         baseUrl,
         userEmail,
-        defaultProjectKey,
         hasWebhookSecret: Boolean(webhookSecretEncrypted),
       },
     });

--- a/src/app/(app)/settings/integrations/jira/page.tsx
+++ b/src/app/(app)/settings/integrations/jira/page.tsx
@@ -14,7 +14,6 @@ export default async function GlobalJiraIntegrationPage() {
       baseUrl: true,
       userEmail: true,
       enabled: true,
-      defaultProjectKey: true,
       webhookSecretEncrypted: true,
       updatedAt: true,
       updatedByUser: {

--- a/src/components/action-items/ActionItemJiraBadge.tsx
+++ b/src/components/action-items/ActionItemJiraBadge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useTransition } from 'react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
 import { ExternalLink, Link2, Loader2, Plus, RefreshCw, Tickets, Trash2 } from 'lucide-react';
@@ -47,6 +48,7 @@ export default function ActionItemJiraBadge({
     return (
       <div
         className="inline-flex items-center gap-1.5 group relative"
+        onClick={event => event.stopPropagation()}
         onMouseEnter={() => setShowActions(true)}
         onMouseLeave={() => setShowActions(false)}
       >
@@ -116,7 +118,7 @@ export default function ActionItemJiraBadge({
 
   if (showLinkForm) {
     return (
-      <div className="inline-flex items-center gap-1.5">
+      <div className="inline-flex items-center gap-1.5" onClick={event => event.stopPropagation()}>
         <Input
           value={linkKey}
           onChange={e => setLinkKey(e.target.value)}
@@ -170,7 +172,7 @@ export default function ActionItemJiraBadge({
   }
 
   return (
-    <div className="inline-flex items-center gap-1">
+    <div className="inline-flex items-center gap-1" onClick={event => event.stopPropagation()}>
       <button
         className="inline-flex items-center gap-1 rounded-full border border-dashed border-slate-300 px-2 py-0.5 text-[10px] font-medium text-muted-foreground hover:border-blue-300 hover:text-blue-600 hover:bg-blue-50 transition-colors"
         onClick={() => {
@@ -187,7 +189,7 @@ export default function ActionItemJiraBadge({
         title="Create Jira issue"
       >
         {isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />}
-        Jira
+        Create Jira
       </button>
       <button
         className="rounded p-0.5 text-muted-foreground hover:text-blue-600 transition-colors"
@@ -198,6 +200,14 @@ export default function ActionItemJiraBadge({
         <Link2 className="h-3 w-3" />
       </button>
       {error && <span className="text-xs text-destructive ml-1">{error}</span>}
+      {error?.includes('not configured') && (
+        <Link
+          href="/settings/integrations/jira"
+          className="text-[10px] font-medium text-blue-600 hover:underline"
+        >
+          Configure
+        </Link>
+      )}
     </div>
   );
 }

--- a/src/components/incident/detail/IncidentJiraCard.tsx
+++ b/src/components/incident/detail/IncidentJiraCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useTransition } from 'react';
+import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcn/card';
 import { Button } from '@/components/ui/shadcn/button';
 import { Input } from '@/components/ui/shadcn/input';
@@ -34,8 +35,10 @@ type JiraLink = {
 
 interface IncidentJiraCardProps {
   incidentId: string;
+  serviceSettingsHref: string;
   jiraLinks: JiraLink[];
   jiraEnabled: boolean;
+  serviceJiraMapped: boolean;
   canManage: boolean;
 }
 
@@ -52,16 +55,16 @@ function statusColor(status: string | null): string {
 
 export default function IncidentJiraCard({
   incidentId,
+  serviceSettingsHref,
   jiraLinks,
   jiraEnabled,
+  serviceJiraMapped,
   canManage,
 }: IncidentJiraCardProps) {
   const [isPending, startTransition] = useTransition();
   const [showLinkForm, setShowLinkForm] = useState(false);
   const [linkKey, setLinkKey] = useState('');
   const [error, setError] = useState<string | null>(null);
-
-  if (!jiraEnabled) return null;
 
   const handleCreate = () => {
     setError(null);
@@ -119,6 +122,29 @@ export default function IncidentJiraCard({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
+        {!jiraEnabled && (
+          <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-3 text-sm text-muted-foreground">
+            <p className="mb-3">Connect Jira to create or link issues from this incident.</p>
+            {canManage && (
+              <Button asChild variant="outline" size="sm" className="h-8">
+                <Link href="/settings/integrations/jira">Configure Jira</Link>
+              </Button>
+            )}
+          </div>
+        )}
+        {jiraEnabled && !serviceJiraMapped && (
+          <div className="rounded-lg border border-dashed border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+            <p className="mb-3">
+              Add a Jira project mapping for this service before creating new Jira issues.
+            </p>
+            {canManage && (
+              <Button asChild variant="outline" size="sm" className="h-8 bg-white">
+                <Link href={serviceSettingsHref}>Configure Service Jira</Link>
+              </Button>
+            )}
+          </div>
+        )}
+
         {error && (
           <Alert variant="destructive" className="py-2">
             <XCircle className="h-3 w-3" />
@@ -216,14 +242,14 @@ export default function IncidentJiraCard({
         )}
 
         {/* Action buttons */}
-        {canManage && !showLinkForm && (
+        {canManage && jiraEnabled && !showLinkForm && (
           <div className="flex gap-2">
             <Button
               variant="outline"
               size="sm"
               className="flex-1 h-8 text-xs"
               onClick={handleCreate}
-              disabled={isPending}
+              disabled={isPending || !serviceJiraMapped}
             >
               {isPending ? (
                 <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />

--- a/src/components/postmortem/PostmortemDetailView.tsx
+++ b/src/components/postmortem/PostmortemDetailView.tsx
@@ -312,11 +312,11 @@ export default function PostmortemDetailView({
                         )}
                       </div>
                       <h4 className="text-base font-semibold mb-1">{item.title}</h4>
-                      {item.externalIssue && (
+                      {!isPublicView && (
                         <ActionItemJiraBadge
                           actionItemId={item.id}
                           externalIssue={item.externalIssue}
-                          canManage={false}
+                          canManage={canEdit}
                           compact
                         />
                       )}

--- a/src/components/service/JiraServiceMappingSettings.tsx
+++ b/src/components/service/JiraServiceMappingSettings.tsx
@@ -24,8 +24,15 @@ type JiraMapping = {
   defaultLabels: string[];
   defaultComponent: string | null;
   autoCreateIncidentIssue: boolean;
+  autoCreateIncidentUrgencies: string[];
   syncEnabled: boolean;
 } | null;
+
+const URGENCY_OPTIONS = [
+  { value: 'HIGH', label: 'High' },
+  { value: 'MEDIUM', label: 'Medium' },
+  { value: 'LOW', label: 'Low' },
+];
 
 function SubmitButton({ disabled }: { disabled: boolean }) {
   const { pending } = useFormStatus();
@@ -52,6 +59,12 @@ export default function JiraServiceMappingSettings({
     error: null,
     success: false,
   });
+  const selectedAutoCreateUrgencies =
+    mapping && mapping.autoCreateIncidentUrgencies.length > 0
+      ? mapping.autoCreateIncidentUrgencies
+      : mapping
+        ? URGENCY_OPTIONS.map(option => option.value)
+        : ['HIGH'];
 
   return (
     <Card>
@@ -74,6 +87,14 @@ export default function JiraServiceMappingSettings({
       <CardContent>
         <form action={formAction} className="space-y-4">
           <input type="hidden" name="serviceId" value={serviceId} />
+          {!jiraEnabled && (
+            <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+              <AlertDescription>
+                You can save this service mapping now. Auto-created Jira issues will start after the
+                workspace Jira integration is connected and enabled.
+              </AlertDescription>
+            </Alert>
+          )}
           {state?.error && (
             <Alert variant="destructive">
               <XCircle className="h-4 w-4" />
@@ -95,7 +116,7 @@ export default function JiraServiceMappingSettings({
                 name="projectKey"
                 defaultValue={mapping?.projectKey ?? ''}
                 placeholder="OPS"
-                disabled={!canManage || !jiraEnabled}
+                disabled={!canManage}
                 required
               />
             </div>
@@ -106,7 +127,7 @@ export default function JiraServiceMappingSettings({
                 name="defaultComponent"
                 defaultValue={mapping?.defaultComponent ?? ''}
                 placeholder="API Platform"
-                disabled={!canManage || !jiraEnabled}
+                disabled={!canManage}
               />
             </div>
             <div className="space-y-2">
@@ -115,7 +136,7 @@ export default function JiraServiceMappingSettings({
                 id="incident-issue-type"
                 name="incidentIssueType"
                 defaultValue={mapping?.incidentIssueType ?? 'Bug'}
-                disabled={!canManage || !jiraEnabled}
+                disabled={!canManage}
                 required
               />
             </div>
@@ -125,7 +146,7 @@ export default function JiraServiceMappingSettings({
                 id="action-item-issue-type"
                 name="actionItemIssueType"
                 defaultValue={mapping?.actionItemIssueType ?? 'Task'}
-                disabled={!canManage || !jiraEnabled}
+                disabled={!canManage}
                 required
               />
             </div>
@@ -136,7 +157,7 @@ export default function JiraServiceMappingSettings({
                 name="defaultLabels"
                 defaultValue={mapping?.defaultLabels.join(', ') ?? 'opsknight'}
                 placeholder="opsknight, incident-response"
-                disabled={!canManage || !jiraEnabled}
+                disabled={!canManage}
               />
             </div>
           </div>
@@ -147,7 +168,7 @@ export default function JiraServiceMappingSettings({
                 type="checkbox"
                 name="autoCreateIncidentIssue"
                 defaultChecked={mapping?.autoCreateIncidentIssue ?? false}
-                disabled={!canManage || !jiraEnabled}
+                disabled={!canManage}
                 className="h-4 w-4"
               />
               Auto-create Jira issues for new incidents
@@ -157,15 +178,34 @@ export default function JiraServiceMappingSettings({
                 type="checkbox"
                 name="syncEnabled"
                 defaultChecked={mapping?.syncEnabled ?? true}
-                disabled={!canManage || !jiraEnabled}
+                disabled={!canManage}
                 className="h-4 w-4"
               />
               Sync Jira status metadata
             </label>
           </div>
 
+          <div className="rounded-md border p-3">
+            <Label className="text-sm font-medium">Auto-create for incident urgency</Label>
+            <div className="mt-3 grid gap-2 sm:grid-cols-3">
+              {URGENCY_OPTIONS.map(option => (
+                <label key={option.value} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    name="autoCreateIncidentUrgencies"
+                    value={option.value}
+                    defaultChecked={selectedAutoCreateUrgencies.includes(option.value)}
+                    disabled={!canManage}
+                    className="h-4 w-4"
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </div>
+          </div>
+
           <div className="flex justify-end border-t pt-4">
-            <SubmitButton disabled={!canManage || !jiraEnabled} />
+            <SubmitButton disabled={!canManage} />
           </div>
         </form>
       </CardContent>

--- a/src/components/settings/JiraIntegrationPage.tsx
+++ b/src/components/settings/JiraIntegrationPage.tsx
@@ -15,7 +15,6 @@ type JiraConfigView = {
   baseUrl: string;
   userEmail: string;
   enabled: boolean;
-  defaultProjectKey: string | null;
   webhookSecretEncrypted: string | null;
   updatedAt: Date;
   updatedByUser: {
@@ -148,16 +147,6 @@ export default function JiraIntegrationPage({
                 placeholder="Paste Jira API token"
                 disabled={!isAdmin}
                 required={!config}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="defaultProjectKey">Default Project Key</Label>
-              <Input
-                id="defaultProjectKey"
-                name="defaultProjectKey"
-                defaultValue={config?.defaultProjectKey ?? ''}
-                placeholder="OPS"
-                disabled={!isAdmin}
               />
             </div>
             <div className="space-y-2">

--- a/src/lib/sla-server.ts
+++ b/src/lib/sla-server.ts
@@ -17,10 +17,7 @@ import {
   shouldUseRollups,
   type RetentionPolicy,
 } from './retention-policy';
-import {
-  incidentEventSqlPredicate,
-  incidentEventWhereFor,
-} from './incident-event-classifier';
+import { incidentEventSqlPredicate, incidentEventWhereFor } from './incident-event-classifier';
 import { mergeHybridMetrics } from './sla-hybrid-merge';
 
 // UUID validation regex - prevents SQL injection in dynamic CASE statements
@@ -38,19 +35,18 @@ const CUID_REGEX = /^c[a-z0-9]{24,}$/i;
  * @param tableAlias - Optional SQL alias prefix (e.g. `i` for `i."status"`).
  *   Pass an empty string to produce un-aliased column references.
  */
-function buildIncidentFilterSql(
-  filters: SLAMetricsFilter,
-  tableAlias: string = ''
-): Prisma.Sql {
+function buildIncidentFilterSql(filters: SLAMetricsFilter, tableAlias: string = ''): Prisma.Sql {
   const prefix = tableAlias ? `${tableAlias}.` : '';
   const fragments: Prisma.Sql[] = [];
 
   // serviceId — scalar or array
   if (filters.serviceId) {
     if (Array.isArray(filters.serviceId)) {
-      fragments.push(
-        Prisma.sql`AND ${Prisma.raw(`${prefix}"serviceId"`)} = ANY(${filters.serviceId}::text[])`
-      );
+      if (filters.serviceId.length > 0) {
+        fragments.push(
+          Prisma.sql`AND ${Prisma.raw(`${prefix}"serviceId"`)} IN (${Prisma.join(filters.serviceId)})`
+        );
+      }
     } else {
       fragments.push(Prisma.sql`AND ${Prisma.raw(`${prefix}"serviceId"`)} = ${filters.serviceId}`);
     }
@@ -64,11 +60,13 @@ function buildIncidentFilterSql(
   // affordance for the recent window only.
   if (filters.teamId) {
     const teamIds = Array.isArray(filters.teamId) ? filters.teamId : [filters.teamId];
-    fragments.push(
-      Prisma.sql`AND ${Prisma.raw(`${prefix}"serviceId"`)} IN (
-        SELECT id FROM "Service" WHERE "teamId" = ANY(${teamIds}::text[])
-      )`
-    );
+    if (teamIds.length > 0) {
+      fragments.push(
+        Prisma.sql`AND ${Prisma.raw(`${prefix}"serviceId"`)} IN (
+          SELECT id FROM "Service" WHERE "teamId" IN (${Prisma.join(teamIds)})
+        )`
+      );
+    }
   }
 
   if (filters.urgency) {
@@ -744,9 +742,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
     const serviceIdForProbe = Array.isArray(filters.serviceId)
       ? filters.serviceId[0]
       : filters.serviceId;
-    const teamIdForProbe = Array.isArray(filters.teamId)
-      ? filters.teamId[0]
-      : filters.teamId;
+    const teamIdForProbe = Array.isArray(filters.teamId) ? filters.teamId[0] : filters.teamId;
     const probe = await prisma.incidentMetricRollup.findFirst({
       where: {
         date: { gte: finalStart, lt: realtimeStart },
@@ -1991,8 +1987,7 @@ export async function calculateSLAMetrics(filters: SLAMetricsFilter = {}): Promi
   // `reopenCountFinal`.
   const resolvedCountForCalc = dbAggMetrics ? dbAggMetrics.resolvedCount : solvedIncidents.length;
   const autoResolvedCount = autoResolveCountFinal;
-  const reopenRate =
-    resolvedCountForCalc > 0 ? (reopenCountFinal / resolvedCountForCalc) * 100 : 0;
+  const reopenRate = resolvedCountForCalc > 0 ? (reopenCountFinal / resolvedCountForCalc) * 100 : 0;
   const rawManualResolved = resolvedCountForCalc - autoResolvedCount;
   if (rawManualResolved < 0) {
     logger.warn('[SLA] manualResolved computed as negative in live path; clamping to 0', {
@@ -2783,13 +2778,9 @@ export async function calculateSLAMetricsFromRollups(
       // lifecycle rather than report 0% for un-backfilled days.
       perPriorityAvailable = perPriorityRows.length > 0;
     } catch (perPriorityErr) {
-      logger.warn(
-        '[SLA] per-priority side-table read failed; falling back to aggregate rollups',
-        {
-          error:
-            perPriorityErr instanceof Error ? perPriorityErr.message : String(perPriorityErr),
-        }
-      );
+      logger.warn('[SLA] per-priority side-table read failed; falling back to aggregate rollups', {
+        error: perPriorityErr instanceof Error ? perPriorityErr.message : String(perPriorityErr),
+      });
     }
   }
 


### PR DESCRIPTION
Summary:
- Make Jira project mapping service-owned (workspace config only stores auth/webhook)
- Add service setting to auto-create Jira issues for incidents, filtered by urgency
- Improve incident Jira card guidance when service mapping is missing
- Add rolling-safe migration for JiraServiceMapping.autoCreateIncidentUrgencies

Notes:
- Pre-push checks run automatically on push; build succeeded but reported existing npm audit vulnerabilities.