### PR TITLE
fix(jira): Use upsert for ExternalIssueLink to prevent unique constraint crashes

### DIFF
--- a/src/lib/jira-sync.ts
+++ b/src/lib/jira-sync.ts
@@ -36,12 +36,28 @@ export async function createJiraIssueAndLink(params: CreateAndLinkParams) {
     component: params.component,
   });
 
-  const link = await prisma.externalIssueLink.create({
-    data: {
+  const link = await prisma.externalIssueLink.upsert({
+    where: {
+      provider_externalId: {
+        provider: params.provider ?? 'JIRA',
+        externalId: issue.id,
+      },
+    },
+    create: {
       provider: params.provider ?? 'JIRA',
       incidentId: params.incidentId ?? null,
       actionItemId: params.actionItemId ?? null,
       externalId: issue.id,
+      externalKey: issue.key,
+      externalUrl: issue.url,
+      externalStatus: issue.status ?? null,
+      externalAssignee: issue.assignee ?? null,
+      syncState: 'SYNCED',
+      lastSyncedAt: new Date(),
+    },
+    update: {
+      incidentId: params.incidentId ?? undefined,
+      actionItemId: params.actionItemId ?? undefined,
       externalKey: issue.key,
       externalUrl: issue.url,
       externalStatus: issue.status ?? null,
@@ -95,13 +111,29 @@ export async function linkExistingJiraIssue(params: LinkExistingParams) {
 
   const issue = await getJiraIssue(key);
 
-  const link = await prisma.externalIssueLink.create({
-    data: {
+  const link = await prisma.externalIssueLink.upsert({
+    where: {
+      provider_externalKey: {
+        provider: params.provider ?? 'JIRA',
+        externalKey: key,
+      },
+    },
+    create: {
       provider: params.provider ?? 'JIRA',
       incidentId: params.incidentId ?? null,
       actionItemId: params.actionItemId ?? null,
       externalId: issue.id,
       externalKey: issue.key,
+      externalUrl: issue.url,
+      externalStatus: issue.status ?? null,
+      externalAssignee: issue.assignee ?? null,
+      syncState: 'SYNCED',
+      lastSyncedAt: new Date(),
+    },
+    update: {
+      incidentId: params.incidentId ?? undefined,
+      actionItemId: params.actionItemId ?? undefined,
+      externalId: issue.id,
       externalUrl: issue.url,
       externalStatus: issue.status ?? null,
       externalAssignee: issue.assignee ?? null,


### PR DESCRIPTION
## Summary

Fixes a crash when linking or creating Jira issues that already have a link record in the database.

## Root Cause
When an issue is created in Jira or synced via a background trigger/webhook, `ExternalIssueLink` already contains a row with `(provider, externalId)`. Calling `prisma.externalIssueLink.create()` threw a Prisma `Unique constraint failed on the fields: (provider, externalId)` error.

## Changes
- Replaced `prisma.externalIssueLink.create()` with `prisma.externalIssueLink.upsert()` in both `createJiraIssueAndLink` and `linkExistingJiraIssue` in `src/lib/jira-sync.ts`.
- If a link record already exists, it updates the existing link record seamlessly instead of throwing a unique constraint failure.

## Files Changed
- `src/lib/jira-sync.ts` (+36, -4 lines)