### PR TITLE
fix(jira): Prevent Next.js production error redaction by returning result objects from server actions

### DIFF
--- a/src/app/(app)/action-items/jira/actions.ts
+++ b/src/app/(app)/action-items/jira/actions.ts
@@ -9,109 +9,198 @@ import {
 } from '@/lib/jira-sync';
 import { revalidatePath } from 'next/cache';
 
-export async function createJiraIssueFromActionItem(actionItemId: string) {
-  await assertAdminOrResponder();
+export type JiraActionResult = {
+  success: boolean;
+  error?: string;
+  key?: string;
+  url?: string;
+};
 
-  const actionItem = await prisma.actionItem.findUnique({
-    where: { id: actionItemId },
-    include: {
-      incident: {
-        include: {
-          service: {
-            include: {
-              jiraServiceMapping: true,
+export async function createJiraIssueFromActionItem(
+  actionItemId: string
+): Promise<JiraActionResult> {
+  try {
+    await assertAdminOrResponder();
+
+    const actionItem = await prisma.actionItem.findUnique({
+      where: { id: actionItemId },
+      include: {
+        incident: {
+          include: {
+            service: {
+              include: {
+                jiraServiceMapping: true,
+              },
             },
           },
         },
       },
-    },
-  });
+    });
 
-  if (!actionItem) throw new Error('Action item not found.');
+    if (!actionItem) return { success: false, error: 'Action item not found.' };
 
-  const mapping = actionItem.incident?.service?.jiraServiceMapping;
+    const mapping = actionItem.incident?.service?.jiraServiceMapping;
 
-  const jiraConfig = await prisma.jiraConfig.findUnique({
-    where: { id: 'default' },
-    select: { enabled: true },
-  });
+    const jiraConfig = await prisma.jiraConfig.findUnique({
+      where: { id: 'default' },
+      select: { enabled: true },
+    });
 
-  if (!jiraConfig?.enabled) throw new Error('Jira is not configured or is disabled.');
+    if (!jiraConfig?.enabled) {
+      return { success: false, error: 'Jira is not configured or is disabled in workspace settings.' };
+    }
 
-  const projectKey = mapping?.projectKey;
-  if (!projectKey) {
-    throw new Error('Configure a Jira project for this action item service first.');
+    const projectKey = mapping?.projectKey;
+    if (!projectKey) {
+      return {
+        success: false,
+        error: 'Configure a Jira project for this service in Service Settings first.',
+      };
+    }
+
+    const issueType = mapping?.actionItemIssueType ?? 'Task';
+    const labels = mapping?.defaultLabels ?? ['opsknight'];
+    const component = mapping?.defaultComponent ?? null;
+
+    let issue;
+    try {
+      const result = await createJiraIssueAndLink({
+        actionItemId,
+        projectKey,
+        issueType,
+        summary: actionItem.title,
+        description: actionItem.description || actionItem.title,
+        labels,
+        component,
+      });
+      issue = result.issue;
+    } catch (error) {
+      const rawMsg = error instanceof Error ? error.message : String(error);
+      if (rawMsg.includes("target project doesn't exist")) {
+        return {
+          success: false,
+          error: `Jira project "${projectKey}" does not exist or your API token lacks permissions. Check Services → Settings → Jira Mapping.`,
+        };
+      }
+      if (rawMsg.includes('issue type')) {
+        return {
+          success: false,
+          error: `Jira issue type "${issueType}" is invalid for project "${projectKey}". Change Action Item Issue Type to "Task" in Services → Settings → Jira Mapping.`,
+        };
+      }
+      return { success: false, error: `Jira issue creation failed: ${rawMsg}` };
+    }
+
+    revalidatePath(`/postmortems/${actionItem.incidentId}`);
+    revalidatePath('/action-items');
+    return { success: true, key: issue.key, url: issue.url };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to create Jira issue.',
+    };
   }
-
-  const issueType = mapping?.actionItemIssueType ?? 'Task';
-  const labels = mapping?.defaultLabels ?? ['opsknight'];
-  const component = mapping?.defaultComponent ?? null;
-
-  const { issue } = await createJiraIssueAndLink({
-    actionItemId,
-    projectKey,
-    issueType,
-    summary: actionItem.title,
-    description: actionItem.description || actionItem.title,
-    labels,
-    component,
-  });
-
-  revalidatePath(`/postmortems/${actionItem.incidentId}`);
-  revalidatePath('/action-items');
-  return { key: issue.key, url: issue.url };
 }
 
-export async function linkJiraIssueToActionItem(actionItemId: string, jiraKey: string) {
-  await assertAdminOrResponder();
+export async function linkJiraIssueToActionItem(
+  actionItemId: string,
+  jiraKey: string
+): Promise<JiraActionResult> {
+  try {
+    await assertAdminOrResponder();
 
-  const actionItem = await prisma.actionItem.findUnique({
-    where: { id: actionItemId },
-    select: { id: true, incidentId: true },
-  });
-  if (!actionItem) throw new Error('Action item not found.');
+    const actionItem = await prisma.actionItem.findUnique({
+      where: { id: actionItemId },
+      select: { id: true, incidentId: true },
+    });
+    if (!actionItem) return { success: false, error: 'Action item not found.' };
 
-  const { issue } = await linkExistingJiraIssue({
-    actionItemId,
-    jiraKey,
-  });
+    let issue;
+    try {
+      const result = await linkExistingJiraIssue({
+        actionItemId,
+        jiraKey,
+      });
+      issue = result.issue;
+    } catch (error) {
+      const rawMsg = error instanceof Error ? error.message : String(error);
+      if (rawMsg.includes('already linked')) {
+        return {
+          success: false,
+          error: `Jira issue "${jiraKey.trim()}" is already linked to another incident or item.`,
+        };
+      }
+      if (rawMsg.includes('not found') || rawMsg.includes('404')) {
+        return {
+          success: false,
+          error: `Jira issue "${jiraKey.trim()}" was not found in your Jira workspace.`,
+        };
+      }
+      return { success: false, error: `Failed to link Jira issue: ${rawMsg}` };
+    }
 
-  revalidatePath(`/postmortems/${actionItem.incidentId}`);
-  revalidatePath('/action-items');
-  return { key: issue.key, url: issue.url };
+    revalidatePath(`/postmortems/${actionItem.incidentId}`);
+    revalidatePath('/action-items');
+    return { success: true, key: issue.key, url: issue.url };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to link Jira issue.',
+    };
+  }
 }
 
-export async function unlinkJiraIssueFromActionItem(linkId: string) {
-  await assertAdminOrResponder();
+export async function unlinkJiraIssueFromActionItem(
+  linkId: string
+): Promise<JiraActionResult> {
+  try {
+    await assertAdminOrResponder();
 
-  const link = await prisma.externalIssueLink.findUnique({
-    where: { id: linkId },
-    select: { id: true, actionItem: { select: { incidentId: true } } },
-  });
-  if (!link) throw new Error('Link not found.');
+    const link = await prisma.externalIssueLink.findUnique({
+      where: { id: linkId },
+      select: { id: true, actionItem: { select: { incidentId: true } } },
+    });
+    if (!link) return { success: false, error: 'Link not found.' };
 
-  await prisma.externalIssueLink.delete({
-    where: { id: linkId },
-  });
+    await prisma.externalIssueLink.delete({
+      where: { id: linkId },
+    });
 
-  if (link.actionItem?.incidentId) {
-    revalidatePath(`/postmortems/${link.actionItem.incidentId}`);
+    if (link.actionItem?.incidentId) {
+      revalidatePath(`/postmortems/${link.actionItem.incidentId}`);
+    }
+    revalidatePath('/action-items');
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to unlink Jira issue.',
+    };
   }
-  revalidatePath('/action-items');
 }
 
-export async function syncActionItemJiraIssue(linkId: string) {
-  await assertAdminOrResponder();
+export async function syncActionItemJiraIssue(
+  linkId: string
+): Promise<JiraActionResult> {
+  try {
+    await assertAdminOrResponder();
 
-  const link = await prisma.externalIssueLink.findUnique({
-    where: { id: linkId },
-    select: { actionItem: { select: { incidentId: true } } },
-  });
+    const link = await prisma.externalIssueLink.findUnique({
+      where: { id: linkId },
+      select: { actionItem: { select: { incidentId: true } } },
+    });
 
-  await syncExternalIssueLink(linkId);
+    await syncExternalIssueLink(linkId);
 
-  if (link?.actionItem?.incidentId) {
-    revalidatePath(`/postmortems/${link.actionItem.incidentId}`);
+    if (link?.actionItem?.incidentId) {
+      revalidatePath(`/postmortems/${link.actionItem.incidentId}`);
+    }
+    revalidatePath('/action-items');
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to sync Jira issue.',
+    };
   }
-  revalidatePath('/action-items');
 }

--- a/src/app/(app)/incidents/jira/actions.ts
+++ b/src/app/(app)/incidents/jira/actions.ts
@@ -9,148 +9,215 @@ import {
 } from '@/lib/jira-sync';
 import { revalidatePath } from 'next/cache';
 
-export async function createJiraIssueFromIncident(incidentId: string) {
-  await assertAdminOrResponder();
+export type JiraActionResult = {
+  success: boolean;
+  error?: string;
+  key?: string;
+  url?: string;
+};
 
-  const incident = await prisma.incident.findUnique({
-    where: { id: incidentId },
-    include: {
-      service: {
-        include: {
-          jiraServiceMapping: true,
+export async function createJiraIssueFromIncident(
+  incidentId: string
+): Promise<JiraActionResult> {
+  try {
+    await assertAdminOrResponder();
+
+    const incident = await prisma.incident.findUnique({
+      where: { id: incidentId },
+      include: {
+        service: {
+          include: {
+            jiraServiceMapping: true,
+          },
         },
       },
-    },
-  });
-
-  if (!incident) throw new Error('Incident not found.');
-
-  const mapping = incident.service?.jiraServiceMapping;
-
-  const jiraConfig = await prisma.jiraConfig.findUnique({
-    where: { id: 'default' },
-    select: { enabled: true },
-  });
-
-  if (!jiraConfig?.enabled) throw new Error('Jira is not configured or is disabled.');
-
-  const projectKey = mapping?.projectKey;
-  if (!projectKey) {
-    throw new Error('Configure a Jira project for this service before creating Jira issues.');
-  }
-
-  const issueType = mapping?.incidentIssueType ?? 'Bug';
-  const labels = mapping?.defaultLabels ?? ['opsknight'];
-  const component = mapping?.defaultComponent ?? null;
-
-  const summary = `[Incident] ${incident.title}`;
-  const description = incident.description || `OpsKnight Incident: ${incident.title}`;
-
-  let issue;
-  try {
-    const result = await createJiraIssueAndLink({
-      incidentId,
-      projectKey,
-      issueType,
-      summary,
-      description,
-      labels,
-      component,
     });
-    issue = result.issue;
-  } catch (error) {
-    const rawMsg = error instanceof Error ? error.message : String(error);
-    if (rawMsg.includes("target project doesn't exist")) {
-      throw new Error(
-        `Jira project "${projectKey}" does not exist or your API token lacks permissions. Check Services → Settings → Jira Mapping.`
-      );
-    }
-    if (rawMsg.includes('issue type')) {
-      throw new Error(
-        `Jira issue type "${issueType}" is invalid for project "${projectKey}". Check Services → Settings → Jira Mapping.`
-      );
-    }
-    throw new Error(`Jira issue creation failed: ${rawMsg}`);
-  }
 
-  // Create timeline event
-  await prisma.incidentEvent.create({
-    data: {
-      incidentId,
-      type: 'COMMENT',
-      message: `Jira issue ${issue.key} created`,
-    },
-  });
+    if (!incident) return { success: false, error: 'Incident not found.' };
 
-  revalidatePath(`/incidents/${incidentId}`);
-  return { key: issue.key, url: issue.url };
-}
+    const mapping = incident.service?.jiraServiceMapping;
 
-export async function linkJiraIssueToIncident(incidentId: string, jiraKey: string) {
-  await assertAdminOrResponder();
-
-  const incident = await prisma.incident.findUnique({
-    where: { id: incidentId },
-    select: { id: true },
-  });
-  if (!incident) throw new Error('Incident not found.');
-
-  let issue;
-  try {
-    const result = await linkExistingJiraIssue({
-      incidentId,
-      jiraKey,
+    const jiraConfig = await prisma.jiraConfig.findUnique({
+      where: { id: 'default' },
+      select: { enabled: true },
     });
-    issue = result.issue;
+
+    if (!jiraConfig?.enabled) {
+      return { success: false, error: 'Jira is not configured or is disabled in workspace settings.' };
+    }
+
+    const projectKey = mapping?.projectKey;
+    if (!projectKey) {
+      return {
+        success: false,
+        error: 'Configure a Jira project for this service in Service Settings before creating Jira issues.',
+      };
+    }
+
+    const issueType = mapping?.incidentIssueType ?? 'Bug';
+    const labels = mapping?.defaultLabels ?? ['opsknight'];
+    const component = mapping?.defaultComponent ?? null;
+
+    const summary = `[Incident] ${incident.title}`;
+    const description = incident.description || `OpsKnight Incident: ${incident.title}`;
+
+    let issue;
+    try {
+      const result = await createJiraIssueAndLink({
+        incidentId,
+        projectKey,
+        issueType,
+        summary,
+        description,
+        labels,
+        component,
+      });
+      issue = result.issue;
+    } catch (error) {
+      const rawMsg = error instanceof Error ? error.message : String(error);
+      if (rawMsg.includes("target project doesn't exist")) {
+        return {
+          success: false,
+          error: `Jira project "${projectKey}" does not exist or your API token lacks permissions. Check Services → Settings → Jira Mapping.`,
+        };
+      }
+      if (rawMsg.includes('issue type')) {
+        return {
+          success: false,
+          error: `Jira issue type "${issueType}" is invalid for project "${projectKey}". Change Incident Issue Type to "Task" in Services → Settings → Jira Mapping.`,
+        };
+      }
+      if (rawMsg.includes('Component') || rawMsg.includes('component')) {
+        return {
+          success: false,
+          error: `Component "${component}" does not exist in Jira project "${projectKey}". Clear Default Component in Services → Settings → Jira Mapping.`,
+        };
+      }
+      return { success: false, error: `Jira issue creation failed: ${rawMsg}` };
+    }
+
+    // Create timeline event
+    await prisma.incidentEvent.create({
+      data: {
+        incidentId,
+        type: 'COMMENT',
+        message: `Jira issue ${issue.key} created`,
+      },
+    });
+
+    revalidatePath(`/incidents/${incidentId}`);
+    return { success: true, key: issue.key, url: issue.url };
   } catch (error) {
-    const rawMsg = error instanceof Error ? error.message : String(error);
-    if (rawMsg.includes('already linked')) {
-      throw new Error(`Jira issue "${jiraKey}" is already linked to an incident or item.`);
-    }
-    if (rawMsg.includes('not found') || rawMsg.includes('404')) {
-      throw new Error(`Jira issue "${jiraKey}" was not found in your Jira workspace.`);
-    }
-    throw new Error(`Failed to link Jira issue: ${rawMsg}`);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to create Jira issue.',
+    };
   }
-
-  await prisma.incidentEvent.create({
-    data: {
-      incidentId,
-      type: 'COMMENT',
-      message: `Jira issue ${issue.key} linked`,
-    },
-  });
-
-  revalidatePath(`/incidents/${incidentId}`);
-  return { key: issue.key, url: issue.url };
 }
 
-export async function unlinkJiraIssueFromIncident(linkId: string, incidentId: string) {
-  await assertAdminOrResponder();
+export async function linkJiraIssueToIncident(
+  incidentId: string,
+  jiraKey: string
+): Promise<JiraActionResult> {
+  try {
+    await assertAdminOrResponder();
 
-  const link = await prisma.externalIssueLink.findUnique({
-    where: { id: linkId },
-    select: { id: true, externalKey: true, incidentId: true },
-  });
-  if (!link || link.incidentId !== incidentId) throw new Error('Link not found.');
+    const incident = await prisma.incident.findUnique({
+      where: { id: incidentId },
+      select: { id: true },
+    });
+    if (!incident) return { success: false, error: 'Incident not found.' };
 
-  await prisma.externalIssueLink.delete({
-    where: { id: linkId },
-  });
+    let issue;
+    try {
+      const result = await linkExistingJiraIssue({
+        incidentId,
+        jiraKey,
+      });
+      issue = result.issue;
+    } catch (error) {
+      const rawMsg = error instanceof Error ? error.message : String(error);
+      if (rawMsg.includes('already linked')) {
+        return {
+          success: false,
+          error: `Jira issue "${jiraKey.trim()}" is already linked to another incident or item.`,
+        };
+      }
+      if (rawMsg.includes('not found') || rawMsg.includes('404')) {
+        return {
+          success: false,
+          error: `Jira issue "${jiraKey.trim()}" was not found in your Jira workspace.`,
+        };
+      }
+      return { success: false, error: `Failed to link Jira issue: ${rawMsg}` };
+    }
 
-  await prisma.incidentEvent.create({
-    data: {
-      incidentId,
-      type: 'COMMENT',
-      message: `Jira issue ${link.externalKey} unlinked`,
-    },
-  });
+    await prisma.incidentEvent.create({
+      data: {
+        incidentId,
+        type: 'COMMENT',
+        message: `Jira issue ${issue.key} linked`,
+      },
+    });
 
-  revalidatePath(`/incidents/${incidentId}`);
+    revalidatePath(`/incidents/${incidentId}`);
+    return { success: true, key: issue.key, url: issue.url };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to link Jira issue.',
+    };
+  }
 }
 
-export async function syncIncidentJiraIssue(linkId: string, incidentId: string) {
-  await assertAdminOrResponder();
-  await syncExternalIssueLink(linkId);
-  revalidatePath(`/incidents/${incidentId}`);
+export async function unlinkJiraIssueFromIncident(
+  linkId: string,
+  incidentId: string
+): Promise<JiraActionResult> {
+  try {
+    await assertAdminOrResponder();
+
+    const link = await prisma.externalIssueLink.findUnique({
+      where: { id: linkId },
+      select: { id: true, externalKey: true, incidentId: true },
+    });
+    if (!link || link.incidentId !== incidentId) return { success: false, error: 'Link not found.' };
+
+    await prisma.externalIssueLink.delete({
+      where: { id: linkId },
+    });
+
+    await prisma.incidentEvent.create({
+      data: {
+        incidentId,
+        type: 'COMMENT',
+        message: `Jira issue ${link.externalKey} unlinked`,
+      },
+    });
+
+    revalidatePath(`/incidents/${incidentId}`);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to unlink Jira issue.',
+    };
+  }
+}
+
+export async function syncIncidentJiraIssue(
+  linkId: string,
+  incidentId: string
+): Promise<JiraActionResult> {
+  try {
+    await assertAdminOrResponder();
+    await syncExternalIssueLink(linkId);
+    revalidatePath(`/incidents/${incidentId}`);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to sync Jira issue.',
+    };
+  }
 }

--- a/src/components/action-items/ActionItemJiraBadge.tsx
+++ b/src/components/action-items/ActionItemJiraBadge.tsx
@@ -77,11 +77,8 @@ export default function ActionItemJiraBadge({
               onClick={() => {
                 setError(null);
                 startTransition(async () => {
-                  try {
-                    await syncActionItemJiraIssue(externalIssue.linkId);
-                  } catch (e) {
-                    setError(e instanceof Error ? e.message : 'Sync failed.');
-                  }
+                  const res = await syncActionItemJiraIssue(externalIssue.linkId);
+                  if (!res.success && res.error) setError(res.error);
                 });
               }}
               disabled={isPending}
@@ -94,11 +91,8 @@ export default function ActionItemJiraBadge({
               onClick={() => {
                 setError(null);
                 startTransition(async () => {
-                  try {
-                    await unlinkJiraIssueFromActionItem(externalIssue.linkId);
-                  } catch (e) {
-                    setError(e instanceof Error ? e.message : 'Unlink failed.');
-                  }
+                  const res = await unlinkJiraIssueFromActionItem(externalIssue.linkId);
+                  if (!res.success && res.error) setError(res.error);
                 });
               }}
               disabled={isPending}
@@ -116,6 +110,20 @@ export default function ActionItemJiraBadge({
   // No linked issue — show create/link options
   if (!canManage) return null;
 
+  const handleLinkSubmit = () => {
+    if (!linkKey.trim()) return;
+    setError(null);
+    startTransition(async () => {
+      const res = await linkJiraIssueToActionItem(actionItemId, linkKey.trim());
+      if (!res.success && res.error) {
+        setError(res.error);
+      } else {
+        setLinkKey('');
+        setShowLinkForm(false);
+      }
+    });
+  };
+
   if (showLinkForm) {
     return (
       <div className="inline-flex items-center gap-1.5" onClick={event => event.stopPropagation()}>
@@ -128,17 +136,7 @@ export default function ActionItemJiraBadge({
           onKeyDown={e => {
             if (e.key === 'Enter') {
               e.preventDefault();
-              if (!linkKey.trim()) return;
-              setError(null);
-              startTransition(async () => {
-                try {
-                  await linkJiraIssueToActionItem(actionItemId, linkKey.trim());
-                  setLinkKey('');
-                  setShowLinkForm(false);
-                } catch (err) {
-                  setError(err instanceof Error ? err.message : 'Link failed.');
-                }
-              });
+              handleLinkSubmit();
             } else if (e.key === 'Escape') {
               setShowLinkForm(false);
               setLinkKey('');
@@ -149,19 +147,7 @@ export default function ActionItemJiraBadge({
           variant="ghost"
           size="icon"
           className="h-6 w-6"
-          onClick={() => {
-            if (!linkKey.trim()) return;
-            setError(null);
-            startTransition(async () => {
-              try {
-                await linkJiraIssueToActionItem(actionItemId, linkKey.trim());
-                setLinkKey('');
-                setShowLinkForm(false);
-              } catch (err) {
-                setError(err instanceof Error ? err.message : 'Link failed.');
-              }
-            });
-          }}
+          onClick={handleLinkSubmit}
           disabled={isPending || !linkKey.trim()}
         >
           {isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Link2 className="h-3 w-3" />}
@@ -178,11 +164,8 @@ export default function ActionItemJiraBadge({
         onClick={() => {
           setError(null);
           startTransition(async () => {
-            try {
-              await createJiraIssueFromActionItem(actionItemId);
-            } catch (e) {
-              setError(e instanceof Error ? e.message : 'Create failed.');
-            }
+            const res = await createJiraIssueFromActionItem(actionItemId);
+            if (!res.success && res.error) setError(res.error);
           });
         }}
         disabled={isPending}

--- a/src/components/incident/detail/IncidentJiraCard.tsx
+++ b/src/components/incident/detail/IncidentJiraCard.tsx
@@ -69,10 +69,9 @@ export default function IncidentJiraCard({
   const handleCreate = () => {
     setError(null);
     startTransition(async () => {
-      try {
-        await createJiraIssueFromIncident(incidentId);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Failed to create Jira issue.');
+      const res = await createJiraIssueFromIncident(incidentId);
+      if (!res.success && res.error) {
+        setError(res.error);
       }
     });
   };
@@ -81,12 +80,12 @@ export default function IncidentJiraCard({
     if (!linkKey.trim()) return;
     setError(null);
     startTransition(async () => {
-      try {
-        await linkJiraIssueToIncident(incidentId, linkKey.trim());
+      const res = await linkJiraIssueToIncident(incidentId, linkKey.trim());
+      if (!res.success && res.error) {
+        setError(res.error);
+      } else {
         setLinkKey('');
         setShowLinkForm(false);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Failed to link Jira issue.');
       }
     });
   };
@@ -94,10 +93,9 @@ export default function IncidentJiraCard({
   const handleUnlink = (linkId: string) => {
     setError(null);
     startTransition(async () => {
-      try {
-        await unlinkJiraIssueFromIncident(linkId, incidentId);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Failed to unlink Jira issue.');
+      const res = await unlinkJiraIssueFromIncident(linkId, incidentId);
+      if (!res.success && res.error) {
+        setError(res.error);
       }
     });
   };
@@ -105,10 +103,9 @@ export default function IncidentJiraCard({
   const handleSync = (linkId: string) => {
     setError(null);
     startTransition(async () => {
-      try {
-        await syncIncidentJiraIssue(linkId, incidentId);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Failed to sync Jira issue.');
+      const res = await syncIncidentJiraIssue(linkId, incidentId);
+      if (!res.success && res.error) {
+        setError(res.error);
       }
     });
   };


### PR DESCRIPTION
## Summary

Eliminates the generic Next.js production error box (`An error occurred in the Server Components render. The specific message is omitted in production builds...`) across all Jira workflows.

## Technical Cause
In Next.js App Router, throwing an uncaught `Error` inside a Server Action causes Next.js in production mode (`NODE_ENV=production`) to redact the error message to prevent sensitive data leaks.

## Fix Implemented
- Updated all Jira server actions (`incidents/jira/actions.ts` & `action-items/jira/actions.ts`) to return plain `{ success: boolean, error?: string, key?: string }` objects instead of throwing uncaught exceptions.
- Updated `IncidentJiraCard` and `ActionItemJiraBadge` UI components to read `res.error` and display specific, friendly error warnings directly inside the UI.

## Result
Users will now ALWAYS see the exact, helpful error (e.g. *"Jira issue SCRUM-4 is already linked to another incident"*, *"Component API Platform does not exist in Jira project SCRUM"*) instead of generic production error digests!

## Files Changed (4)
- `src/app/(app)/incidents/jira/actions.ts`
- `src/app/(app)/action-items/jira/actions.ts`
- `src/components/incident/detail/IncidentJiraCard.tsx`
- `src/components/action-items/ActionItemJiraBadge.tsx`