### PR TITLE
feat(jira): Sync incident notes and updates as comments to linked Jira issues

### DIFF
--- a/src/app/(app)/incidents/actions.ts
+++ b/src/app/(app)/incidents/actions.ts
@@ -777,6 +777,14 @@ export async function addNote(incidentId: string, content: string) {
   });
 
   revalidatePath(`/incidents/${incidentId}`);
+
+  // Best-effort sync note to any linked Jira tickets
+  try {
+    const { syncIncidentNoteToJira } = await import('@/lib/jira-sync');
+    await syncIncidentNoteToJira(incidentId, user.name, content);
+  } catch (e) {
+    logger.error('Jira note sync failed', { component: 'incidents-actions', error: e, incidentId });
+  }
 }
 
 export async function reassignIncident(incidentId: string, assigneeId: string, teamId?: string) {

--- a/src/lib/jira-sync.ts
+++ b/src/lib/jira-sync.ts
@@ -1,7 +1,8 @@
 import prisma from '@/lib/prisma';
-import { createJiraIssue, getJiraIssue, type JiraIssueSummary } from '@/lib/jira';
+import { createJiraIssue, getJiraIssue, addJiraComment, type JiraIssueSummary } from '@/lib/jira';
 import { isValidJiraKey, extractJiraKey } from '@/lib/jira-validation';
 import { logAudit, getDefaultActorId } from '@/lib/audit';
+import { logger } from '@/lib/logger';
 
 export type CreateAndLinkParams = {
   provider?: 'JIRA';
@@ -266,3 +267,70 @@ export async function processJiraWebhookEvent(
 
   return { updated: links.length };
 }
+
+/**
+ * Post a note/comment from an OpsKnight incident to all linked Jira issues.
+ * Best-effort so failures never block OpsKnight operations.
+ */
+export async function syncIncidentNoteToJira(
+  incidentId: string,
+  authorName: string,
+  noteContent: string
+): Promise<number> {
+  try {
+    const links = await prisma.externalIssueLink.findMany({
+      where: { incidentId, provider: 'JIRA' },
+      select: { externalKey: true },
+    });
+
+    if (links.length === 0) return 0;
+
+    const formattedComment = `[OpsKnight Note by ${authorName}]:\n${noteContent}`;
+
+    await Promise.allSettled(
+      links.map(link => addJiraComment(link.externalKey, formattedComment))
+    );
+
+    return links.length;
+  } catch (error) {
+    logger.error('Failed to sync incident note to Jira', {
+      component: 'jira-sync',
+      incidentId,
+      error,
+    });
+    return 0;
+  }
+}
+
+/**
+ * Post a status update event from an OpsKnight incident to all linked Jira issues.
+ */
+export async function syncIncidentEventToJira(
+  incidentId: string,
+  eventMessage: string
+): Promise<number> {
+  try {
+    const links = await prisma.externalIssueLink.findMany({
+      where: { incidentId, provider: 'JIRA' },
+      select: { externalKey: true },
+    });
+
+    if (links.length === 0) return 0;
+
+    const formattedComment = `[OpsKnight Update]: ${eventMessage}`;
+
+    await Promise.allSettled(
+      links.map(link => addJiraComment(link.externalKey, formattedComment))
+    );
+
+    return links.length;
+  } catch (error) {
+    logger.error('Failed to sync incident event to Jira', {
+      component: 'jira-sync',
+      incidentId,
+      error,
+    });
+    return 0;
+  }
+}
+

--- a/src/lib/jira.ts
+++ b/src/lib/jira.ts
@@ -166,3 +166,21 @@ export async function getJiraIssue(issueKeyOrId: string): Promise<JiraIssueSumma
     assignee: issue.fields?.assignee?.displayName ?? issue.fields?.assignee?.emailAddress,
   };
 }
+
+export async function addJiraComment(
+  issueKeyOrId: string,
+  commentText: string
+): Promise<void> {
+  const config = await getDecryptedJiraConfig();
+  if (!config) return;
+
+  const payload = {
+    body: toADF(commentText),
+  };
+
+  await jiraRequest(config, `/rest/api/3/issue/${encodeURIComponent(issueKeyOrId)}/comment`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+


### PR DESCRIPTION
## Summary

Improves bi-directional Jira synchronization by automatically posting incident notes/comments to all linked Jira tickets.

## Features Added
1. **Jira REST API Comment Endpoint**: Added `addJiraComment(issueKeyOrId, commentText)` in `src/lib/jira.ts`.
2. **Note & Event Sync Helpers**: Added `syncIncidentNoteToJira(incidentId, authorName, noteContent)` and `syncIncidentEventToJira(incidentId, eventMessage)` in `src/lib/jira-sync.ts`.
3. **Incident Note Hook**: Integrated Jira comment sync in `addNote` (`src/app/(app)/incidents/actions.ts`).

## How it works:
- When any responder/user adds a note to an incident in OpsKnight (e.g. *"Fixed DB connection Pool"*), OpsKnight automatically posts a comment to every linked Jira ticket (`SCRUM-1`, `SCRUM-2`, etc.):
  `[OpsKnight Note by Alice]: Fixed DB connection Pool`
- Operations are best-effort (wrapped in try/catch) so Jira API slowdowns never block OpsKnight incident workflows.

## Files Changed
- `src/lib/jira.ts`
- `src/lib/jira-sync.ts`
- `src/app/(app)/incidents/actions.ts`