### PR TITLE
feat(services): Display Slack Notification settings and Jira Mapping side-by-side

### DIFF
--- a/src/app/(app)/services/[id]/settings/page.tsx
+++ b/src/app/(app)/services/[id]/settings/page.tsx
@@ -24,6 +24,7 @@ import {
   Settings,
   Shield,
   Users,
+  Puzzle,
 } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/shadcn/alert';
 
@@ -308,20 +309,40 @@ export default async function ServiceSettingsPage({
             </Card>
           </div>
 
-          {/* Notification Settings (Client Component) */}
-          <div className="mt-6">
-            <ServiceNotificationSettings
-              serviceId={service.id}
-              serviceNotificationChannels={service.serviceNotificationChannels}
-              serviceNotifyOnTriggered={service.serviceNotifyOnTriggered}
-              serviceNotifyOnAck={service.serviceNotifyOnAck}
-              serviceNotifyOnResolved={service.serviceNotifyOnResolved}
-              serviceNotifyOnSlaBreach={service.serviceNotifyOnSlaBreach}
-              slackChannel={service.slackChannel || null}
-              slackWebhookUrl={service.slackWebhookUrl}
-              slackIntegration={globalSlackIntegration}
-              webhookIntegrations={webhookIntegrations}
-            />
+          {/* Integrations & Workflows Section: Slack & Jira Side-by-Side */}
+          <div className="mt-8 pt-6 border-t space-y-4">
+            <div>
+              <h2 className="text-xl font-bold text-slate-900 tracking-tight flex items-center gap-2">
+                <Puzzle className="h-5 w-5 text-primary" /> Service Integrations & Workflows
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Configure notification channels (Slack) and engineering issue tracking (Jira) side-by-side.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+              {/* Slack Notification Settings */}
+              <ServiceNotificationSettings
+                serviceId={service.id}
+                serviceNotificationChannels={service.serviceNotificationChannels}
+                serviceNotifyOnTriggered={service.serviceNotifyOnTriggered}
+                serviceNotifyOnAck={service.serviceNotifyOnAck}
+                serviceNotifyOnResolved={service.serviceNotifyOnResolved}
+                serviceNotifyOnSlaBreach={service.serviceNotifyOnSlaBreach}
+                slackChannel={service.slackChannel || null}
+                slackWebhookUrl={service.slackWebhookUrl}
+                slackIntegration={globalSlackIntegration}
+                webhookIntegrations={webhookIntegrations}
+              />
+
+              {/* Jira Service Mapping Settings */}
+              <JiraServiceMappingSettings
+                serviceId={service.id}
+                mapping={service.jiraServiceMapping}
+                jiraEnabled={jiraConfig?.enabled ?? false}
+                canManage={canManage}
+              />
+            </div>
           </div>
 
           <div className="flex items-center justify-end pt-4 gap-4 border-t mt-8">
@@ -334,13 +355,6 @@ export default async function ServiceSettingsPage({
             </Button>
           </div>
         </form>
-
-        <JiraServiceMappingSettings
-          serviceId={service.id}
-          mapping={service.jiraServiceMapping}
-          jiraEnabled={jiraConfig?.enabled ?? false}
-          canManage={canManage}
-        />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

Positions Slack Notification Settings and Jira Workflow Mapping side-by-side under a dedicated **Service Integrations & Workflows** section in Service Settings.

## Layout Details
- **Side-by-Side 2-Column Grid**: Slack & Notification Channels on the left column, Jira Project & Issue Type Mapping on the right column.
- **Unified Section**: Grouped under **Service Integrations & Workflows** header (`<Puzzle />`).

## Locations Updated
1. **Workspace Level (`/settings/integrations`)**: Slack and Jira integration cards are already displayed side-by-side.
2. **Service Level (`/services/[id]/settings`)**: Now displays Slack & Jira cards side-by-side in a responsive 2-column layout.

## Files Changed
- `src/app/(app)/services/[id]/settings/page.tsx`