### PR TITLE
fix(postmortems): Fix Action Item Jira revalidation paths & render Jira link badge in Postmortem UI

### DIFF
--- a/src/app/(app)/action-items/jira/actions.ts
+++ b/src/app/(app)/action-items/jira/actions.ts
@@ -16,6 +16,18 @@ export type JiraActionResult = {
   url?: string;
 };
 
+function revalidateActionItemPaths(postmortemId?: string | null, incidentId?: string | null) {
+  if (postmortemId) {
+    revalidatePath(`/postmortems/${postmortemId}`);
+  }
+  if (incidentId) {
+    revalidatePath(`/incidents/${incidentId}`);
+    revalidatePath(`/postmortems/${incidentId}`);
+  }
+  revalidatePath('/action-items');
+  revalidatePath('/postmortems');
+}
+
 export async function createJiraIssueFromActionItem(
   actionItemId: string
 ): Promise<JiraActionResult> {
@@ -24,11 +36,16 @@ export async function createJiraIssueFromActionItem(
 
     const actionItem = await prisma.actionItem.findUnique({
       where: { id: actionItemId },
-      include: {
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        postmortemId: true,
+        incidentId: true,
         incident: {
-          include: {
+          select: {
             service: {
-              include: {
+              select: {
                 jiraServiceMapping: true,
               },
             },
@@ -91,8 +108,7 @@ export async function createJiraIssueFromActionItem(
       return { success: false, error: `Jira issue creation failed: ${rawMsg}` };
     }
 
-    revalidatePath(`/postmortems/${actionItem.incidentId}`);
-    revalidatePath('/action-items');
+    revalidateActionItemPaths(actionItem.postmortemId, actionItem.incidentId);
     return { success: true, key: issue.key, url: issue.url };
   } catch (error) {
     return {
@@ -111,7 +127,7 @@ export async function linkJiraIssueToActionItem(
 
     const actionItem = await prisma.actionItem.findUnique({
       where: { id: actionItemId },
-      select: { id: true, incidentId: true },
+      select: { id: true, postmortemId: true, incidentId: true },
     });
     if (!actionItem) return { success: false, error: 'Action item not found.' };
 
@@ -139,8 +155,7 @@ export async function linkJiraIssueToActionItem(
       return { success: false, error: `Failed to link Jira issue: ${rawMsg}` };
     }
 
-    revalidatePath(`/postmortems/${actionItem.incidentId}`);
-    revalidatePath('/action-items');
+    revalidateActionItemPaths(actionItem.postmortemId, actionItem.incidentId);
     return { success: true, key: issue.key, url: issue.url };
   } catch (error) {
     return {
@@ -158,7 +173,10 @@ export async function unlinkJiraIssueFromActionItem(
 
     const link = await prisma.externalIssueLink.findUnique({
       where: { id: linkId },
-      select: { id: true, actionItem: { select: { incidentId: true } } },
+      select: {
+        id: true,
+        actionItem: { select: { postmortemId: true, incidentId: true } },
+      },
     });
     if (!link) return { success: false, error: 'Link not found.' };
 
@@ -166,10 +184,7 @@ export async function unlinkJiraIssueFromActionItem(
       where: { id: linkId },
     });
 
-    if (link.actionItem?.incidentId) {
-      revalidatePath(`/postmortems/${link.actionItem.incidentId}`);
-    }
-    revalidatePath('/action-items');
+    revalidateActionItemPaths(link.actionItem?.postmortemId, link.actionItem?.incidentId);
     return { success: true };
   } catch (error) {
     return {
@@ -187,15 +202,14 @@ export async function syncActionItemJiraIssue(
 
     const link = await prisma.externalIssueLink.findUnique({
       where: { id: linkId },
-      select: { actionItem: { select: { incidentId: true } } },
+      select: {
+        actionItem: { select: { postmortemId: true, incidentId: true } },
+      },
     });
 
     await syncExternalIssueLink(linkId);
 
-    if (link?.actionItem?.incidentId) {
-      revalidatePath(`/postmortems/${link.actionItem.incidentId}`);
-    }
-    revalidatePath('/action-items');
+    revalidateActionItemPaths(link?.actionItem?.postmortemId, link?.actionItem?.incidentId);
     return { success: true };
   } catch (error) {
     return {

--- a/src/components/postmortem/PostmortemActionItems.tsx
+++ b/src/components/postmortem/PostmortemActionItems.tsx
@@ -247,14 +247,14 @@ export default function PostmortemActionItems({
                         )}
                       </div>
                       <h4 className="text-base font-semibold mb-1">{item.title}</h4>
-                      {item.externalIssue && (
+                      <div className="my-1">
                         <ActionItemJiraBadge
                           actionItemId={item.id}
                           externalIssue={item.externalIssue}
-                          canManage={false}
+                          canManage={canManage}
                           compact
                         />
-                      )}
+                      </div>
                       {item.description && (
                         <p className="text-sm text-muted-foreground mb-1">{item.description}</p>
                       )}


### PR DESCRIPTION
## Summary

Fixes the issue where created or linked Jira issues on Postmortem action items were not immediately visible in the UI without a manual browser refresh.

## Root Cause
1. **Wrong Revalidation Path**: `createJiraIssueFromActionItem` called `revalidatePath(/postmortems/${actionItem.incidentId})`. Postmortems are keyed by `postmortemId`, so Next.js revalidated a non-existent path `/postmortems/<incidentId>` and served cached stale postmortem pages.
2. **Hardcoded Disabled UI**: `PostmortemActionItems.tsx` wrapped `ActionItemJiraBadge` in `{item.externalIssue &&` and hardcoded `canManage={false}`, preventing Jira controls/badges from displaying on action items.

## Fix Implemented
1. **Correct Path Revalidation**: Created `revalidateActionItemPaths()` helper in `action-items/jira/actions.ts` that revalidates `/postmortems/${actionItem.postmortemId}`, `/incidents/${actionItem.incidentId}`, `/postmortems`, and `/action-items`.
2. **UI Controls**: Updated `PostmortemActionItems.tsx` to pass `canManage={canManage}` and render `ActionItemJiraBadge` so linked Jira badges (e.g. `SCRUM-4 ↗`) show up immediately upon creation.

## Files Changed
- `src/app/(app)/action-items/jira/actions.ts`
- `src/components/postmortem/PostmortemActionItems.tsx`