### PR TITLE
fix(postmortems): Resolve TS2304 compilation error in PostmortemActionItems

### DIFF
--- a/src/components/postmortem/PostmortemActionItems.tsx
+++ b/src/components/postmortem/PostmortemActionItems.tsx
@@ -25,6 +25,7 @@ import ActionItemJiraBadge from '@/components/action-items/ActionItemJiraBadge';
 interface PostmortemActionItemsProps {
   actionItems: ActionItem[];
   onChange: (items: ActionItem[]) => void;
+  canManage?: boolean;
   users?: Array<{
     id: string;
     name: string;
@@ -39,6 +40,7 @@ import { ACTION_ITEM_STATUS_CONFIG, ACTION_ITEM_PRIORITY_CONFIG } from './shared
 export default function PostmortemActionItems({
   actionItems,
   onChange,
+  canManage = true,
   users = [],
 }: PostmortemActionItemsProps) {
   const { userTimeZone } = useTimezone();


### PR DESCRIPTION
## Summary

Fixes a TypeScript compilation error (`TS2304: Cannot find name "canManage"`) in `src/components/postmortem/PostmortemActionItems.tsx`.

## Fix
Added `canManage?: boolean` to `PostmortemActionItemsProps` interface with a default value of `canManage = true`.

## Files Changed
- `src/components/postmortem/PostmortemActionItems.tsx`