### PR TITLE
fix(ci): Ensure full docs sync parity between app repo and website repo

### DIFF
--- a/scripts/sync-docs-to-website.sh
+++ b/scripts/sync-docs-to-website.sh
@@ -23,8 +23,6 @@ sync_docs_dir() {
 
   mkdir -p "$dest"
   rsync -av --delete \
-    --exclude 'coreconcepts/**' \
-    --exclude 'core-concepts/**' \
     --exclude '.DS_Store' \
     "$src/" "$dest/"
 }


### PR DESCRIPTION
## Summary

Removes stale `--exclude core-concepts/**` flags from `scripts/sync-docs-to-website.sh` to ensure automated `docs-sync.yml` workflow syncs 100% of all documentation folders (including `core-concepts/` and `integrations/`) from `OpsKnight` to `OpsKnight-website` seamlessly.

## Files Updated
- `scripts/sync-docs-to-website.sh`