### PR TITLE
fix(ci): Route image assets exclusively to public/docs/ in sync script

### DIFF
--- a/scripts/sync-docs-to-website.sh
+++ b/scripts/sync-docs-to-website.sh
@@ -23,6 +23,7 @@ sync_docs_dir() {
 
   mkdir -p "$dest"
   rsync -av --delete \
+    --exclude 'assets/**' \
     --exclude '.DS_Store' \
     "$src/" "$dest/"
 }


### PR DESCRIPTION
## Summary

Fixes `scripts/sync-docs-to-website.sh` by adding `--exclude assets/**` to `sync_docs_dir()`.

## Result
1. Markdown document files sync to `content/docs/$version/`.
2. Image assets sync to `public/docs/$version/assets/` (where Next.js serves web images).
3. Prevents binary image files from being copied into `content/docs/$version/assets/` during automated sync runs, protecting Vercel builds from breaking in the future.

## Files Updated
- `scripts/sync-docs-to-website.sh`