### PR TITLE
fix(ci): Restore original sync script architecture

### DIFF
--- a/scripts/sync-docs-to-website.sh
+++ b/scripts/sync-docs-to-website.sh
@@ -23,7 +23,6 @@ sync_docs_dir() {
 
   mkdir -p "$dest"
   rsync -av --delete \
-    --exclude 'assets/**' \
     --exclude '.DS_Store' \
     "$src/" "$dest/"
 }


### PR DESCRIPTION
## Summary

Restores the exact original implementation of `scripts/sync-docs-to-website.sh` to preserve the original architecture.

## Files Updated
- `scripts/sync-docs-to-website.sh`